### PR TITLE
[add]マイグレーションファイルのプロパティ記入

### DIFF
--- a/src/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/src/database/migrations/2014_10_12_000000_create_users_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
+            $table->string('line_id')->nullable();
             $table->string('DisplayName', 50)->nullable();
             $table->string('ProfileImageUrl', 300)->nullable();
             $table->string('prefecture', 15)->nullable();

--- a/src/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/src/database/migrations/2014_10_12_000000_create_users_table.php
@@ -15,12 +15,14 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
-            $table->string('email')->unique();
-            $table->timestamp('email_verified_at')->nullable();
-            $table->string('password');
-            $table->rememberToken();
+            $table->string('DisplayName', 50)->nullable();
+            $table->string('ProfileImageUrl', 300)->nullable();
+            $table->string('prefecture', 15)->nullable();
+            $table->string('city', 15)->nullable();
+            $table->date('birth')->nullable();
+            $table->mediumInteger('gender')->nullable();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/src/database/migrations/2023_08_19_091928_create_reports_table.php
+++ b/src/database/migrations/2023_08_19_091928_create_reports_table.php
@@ -15,7 +15,14 @@ return new class extends Migration
     {
         Schema::create('reports', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('user_id')->constrained();
+            $table->string('title', 30)->nullable();
+            $table->string('content', 300)->nullable();
+            $table->string('address', 30)->nullable();
+            $table->float('lat', 4, 16)->nullable();
+            $table->float('lng', 4, 16)->nullable();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/src/database/migrations/2023_08_19_092108_create_tags_table.php
+++ b/src/database/migrations/2023_08_19_092108_create_tags_table.php
@@ -15,7 +15,9 @@ return new class extends Migration
     {
         Schema::create('tags', function (Blueprint $table) {
             $table->id();
+            $table->string('name', 20)->unique()->nullable();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/src/database/migrations/2023_08_19_092530_create_coinlogs_table.php
+++ b/src/database/migrations/2023_08_19_092530_create_coinlogs_table.php
@@ -15,7 +15,10 @@ return new class extends Migration
     {
         Schema::create('coinlogs', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('user_id')->constrained();
+            $table->bigInteger('amount')->nullable();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/src/database/migrations/2023_08_19_092738_create_questions_table.php
+++ b/src/database/migrations/2023_08_19_092738_create_questions_table.php
@@ -15,7 +15,13 @@ return new class extends Migration
     {
         Schema::create('questions', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('user_id')->constrained();
+            $table->string('prefecture', 15)->nullable();
+            $table->string('city', 15)->nullable();
+            $table->integer('reward')->nullable();
+            $table->string('content', 300)->nullable();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/src/database/migrations/2023_08_20_044219_create_imageurls_table.php
+++ b/src/database/migrations/2023_08_20_044219_create_imageurls_table.php
@@ -15,7 +15,10 @@ return new class extends Migration
     {
         Schema::create('imageurls', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('report_id')->constrained();
+            $table->string('ImageUrl', 300)->nullable();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/src/database/migrations/2023_08_20_044457_create_answers_table.php
+++ b/src/database/migrations/2023_08_20_044457_create_answers_table.php
@@ -15,7 +15,11 @@ return new class extends Migration
     {
         Schema::create('answers', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('question_id')->constrained();
+            $table->foreignId('user_id')->constrained();
+            $table->string('content', 300)->nullable();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/src/database/migrations/2023_08_20_044620_create_favorites_table.php
+++ b/src/database/migrations/2023_08_20_044620_create_favorites_table.php
@@ -15,7 +15,11 @@ return new class extends Migration
     {
         Schema::create('favorites', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('user_id')->constrained();
+            $table->foreignId('report_id')->constrained();
+            $table->boolean('isFavorite')->nullable();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/src/database/migrations/2023_08_20_044735_create_report_tag_table.php
+++ b/src/database/migrations/2023_08_20_044735_create_report_tag_table.php
@@ -14,8 +14,12 @@ return new class extends Migration
     public function up()
     {
         Schema::create('report_tag', function (Blueprint $table) {
-            $table->id();
+            $table->foreignId('tag_id')->constrained();
+            $table->foreignId('report_id')->constrained();
+            $table->boolean('isExist')->nullable();
             $table->timestamps();
+            $table->softDeletes();
+            $table->primary(['tag_id', 'report_id']);
         });
     }
 


### PR DESCRIPTION
# 要件定義 ※
マイグレーションファイルのプロパティ記入

# やったこと、なぜこうしたか ※
- マイグレーションファイルにプロパティを追加した
- 例：$table->string('content', 300)->nullable();

# 見てほしいところ
- 全体的に問題ないか
- ~~userテーブルのidはid()でよいのか~~->良くないのでstring型の主キーにする

# TODO
- まだローカル環境で php artisan migrateコマンドを実行していないので特に問題なければローカル環境でテーブル作っちゃう